### PR TITLE
adapt Nova's DeciderEth prepare_calldata & update examples to it

### DIFF
--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -84,6 +84,7 @@ fn main() {
     // prepare the Nova prover & verifier params
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
+    let pp_hash = nova_params.1.pp_hash().unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0).unwrap();
@@ -131,6 +132,7 @@ fn main() {
 
     let calldata: Vec<u8> = prepare_calldata(
         function_selector,
+        pp_hash,
         nova.i,
         nova.z_0,
         nova.z_i,

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -101,6 +101,7 @@ fn main() {
     // prepare the Nova prover & verifier params
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config.clone(), f_circuit);
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
+    let pp_hash = nova_params.1.pp_hash().unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit, z_0).unwrap();
@@ -138,6 +139,7 @@ fn main() {
 
     let calldata: Vec<u8> = prepare_calldata(
         function_selector,
+        pp_hash,
         nova.i,
         nova.z_0,
         nova.z_i,

--- a/examples/noir_full_flow.rs
+++ b/examples/noir_full_flow.rs
@@ -74,6 +74,7 @@ fn main() {
     // prepare the Nova prover & verifier params
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
+    let pp_hash = nova_params.1.pp_hash().unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0).unwrap();
@@ -119,6 +120,7 @@ fn main() {
 
     let calldata: Vec<u8> = prepare_calldata(
         function_selector,
+        pp_hash,
         nova.i,
         nova.z_0,
         nova.z_i,

--- a/examples/noname_full_flow.rs
+++ b/examples/noname_full_flow.rs
@@ -84,6 +84,7 @@ fn main() {
     // prepare the Nova prover & verifier params
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
+    let pp_hash = nova_params.1.pp_hash().unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0).unwrap();
@@ -131,6 +132,7 @@ fn main() {
 
     let calldata: Vec<u8> = prepare_calldata(
         function_selector,
+        pp_hash,
         nova.i,
         nova.z_0,
         nova.z_i,


### PR DESCRIPTION
My bad, at the previous PR (#1) I've run locally the tests but not the examples, which the GitHub CI revealed that they were failing. This PR updates the method that was causing the error, and adapts the examples to work with the updated version of it.